### PR TITLE
autoplay feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ discord.log
 /data/*.mp3
 test.py
 nssm.exe
+.cache

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ async def on_ready():
 @bot.group(invoke_without_command=True)
 async def help(ctx):
     em = discord.Embed(title='help', description='to get help with a command, use $help <command>.', color=ctx.author.color)
-    em.add_field(name='pic commands', value='`milkies`, `creator`, `dallE`, `findFurry`')
+    em.add_field(name='pic commands', value='`creator`, `dallE`, `findFurry`')
     em.add_field(name='chat commands', value='`heymongrel`, `banmike`, `getNewAssignments`')
     em.add_field(name='voice commands', value="`say`")
     em.add_field(name='game commands', value="`joinQ`, `leaveQ`, `showPlayers`, `clearQ`, `setBet <amount>`, `playPoker`, `playJack`, `resetJack`")
@@ -54,11 +54,6 @@ async def heymongrel(ctx):
 @help.command()
 async def say(ctx):
     em = discord.Embed(title='say', description='usage: `say <what you want bot to say>`. bot speaks requested string in voice channel.')
-    await ctx.send(embed = em)
-
-@help.command()
-async def milkies(ctx):
-    em = discord.Embed(title='milkies', description='try it and find out sweet cheeks ;)')
     await ctx.send(embed = em)
 
 @help.command()

--- a/bot.py
+++ b/bot.py
@@ -161,7 +161,7 @@ async def resetGames(ctx):
 
 @bot.command()
 async def checkCogs(ctx):
-    cogs = ["PlayerQueue", "CanvasClient", "Economy", "MusicController", "Reward"]
+    cogs = ["GamesController", "CanvasClient", "Economy", "MusicController", "RewardsController"]
     cog_string = ""
     for cog in cogs:
         if bot.get_cog(cog) is not None:

--- a/bot.py
+++ b/bot.py
@@ -1,12 +1,12 @@
 from discord.ext import commands
-from config.config import TOKEN
+from config.config import TOKEN, WORKING_DIRECTORY
 import logging
 import discord
 import helper
 
 # BE SURE TO SET REPLICATE API TOKEN TO ENV VARIABLE BEFORE RUNNING
 
-handler = logging.FileHandler(filename='discord.log', encoding='utf-8', mode='w')
+handler = logging.FileHandler(filename=WORKING_DIRECTORY +'discord.log', encoding='utf-8', mode='w')
 
 # 'intents' specify what events our bot will be able to act on. default events covers a lot of events but
 # i make sure to specifically set the 'message_content_ intent to True, bc that's the main intent I will be using

--- a/cogs/controller.py
+++ b/cogs/controller.py
@@ -1,11 +1,11 @@
 from discord.ext.commands.cog import Cog
 
 class Controller(Cog):
-    def __init__(self, bot, controlled_class):
-        """A base class that Cog Controllers derive from.
+    """A base class that Cog Controllers derive from.
         :param self.bot: A reference to the discord Bot which is constructing the Controller.
         :param self.clazz: A reference to the class which the Controller will construct an instance of for each guild the Bot is a part of.
         :param self.gulds_to_clazzs: Dictionary storing all the guilds and clazzs that a controller owns."""
+    def __init__(self, bot, controlled_class):
         self.bot = bot
         self.clazz = controlled_class
         self.guilds_to_clazzs:dict = {guild : self.clazz(self.bot) for guild in self.bot.guilds}

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -303,7 +303,7 @@ class Player:
 
 class PlayerQueue(Cog):
     """
-    The PlayerQueue class is used as a controller of the games available in the games.py 'cog'.\n
+    The PlayerQueue class is used as a guild-level-distributor of the games available in the games.py 'cog'.\n
     self.q is a list[Card]. Each player is stored as a tuple of (Player, Discord.Member) objects so that we can easily access methods to discord members.
     Right now, I'm actually realizing that it would be much more simple if I instead just incorporated the discord.Member object into the Player class as an attribute. Removing the possibility of confusing others with tuples in the player queue."""
     def __init__(self, bot):
@@ -441,7 +441,7 @@ class PlayerQueue(Cog):
             await ctx.send(f"An exception occured, {e}")
 
 class GamesController(Controller):
-    """High level controller of all games. Assigns each guild a PlayerQueue, and routes requests from guilds to their respective PlayerQueue instance."""
+    """High level controller of PlayerQueues. Assigns each guild a PlayerQueue, and routes requests from guilds to their respective PlayerQueue instance."""
     def __init__(self, bot):
         super().__init__(bot, PlayerQueue)
     

--- a/cogs/games.py
+++ b/cogs/games.py
@@ -724,8 +724,6 @@ class BlackJackGame(Cog):
         # empty players before giving opportunity for another round to start
 
 
-# could lowkey create a Game super class that BlackJack and Poker would inherit from - simply making them share attributes such as the 
-# bot, deck, player queue, players, and dealer.
 
 class Poker(commands.Cog):
     """

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -283,6 +283,7 @@ class Player(commands.Cog):
         self.autoplay = False
 
     def play_next(self, err = None):
+        # self.from_skip = False
         logger.debug(f"{getTime()}: play_next method executing")
         playlist = self.playlist
         self.playing = False
@@ -292,7 +293,7 @@ class Player(commands.Cog):
         logger.info(f"{time.asctime(time.localtime())}: ParkBot deleted songs besides those in this list, {song_titles_to_save}")
         #TODO review this `from skip` logic
         if not playlist.isEmpty():
-            if not self.from_skip: # if coming from a skip, don't iterate current song to the next song. (why? current song should be None if coming from a skip.)
+            if not self.from_skip: # if coming from a skip, don't iterate current song to the next song. if coming from a skip, I want to negate this call to play_next
                 playlist.current_song = playlist.playque[0]
             playlist.playque.popleft()
             self.from_skip = False
@@ -331,7 +332,7 @@ class Player(commands.Cog):
             logger.debug(f"{getTime()}: Playlist is not empty so continuing _play_song method.")
             logger.debug(f"{getTime()}: Playlist is not empty! Contents: {[song.title for song in playlist.playque]}")
             if self.voice.is_playing():
-                logger.debug(f"{(getTime())}: Voice is already playing, so returning early.")
+                logger.debug(f"{getTime()}: Voice is already playing, so returning early.")
                 return
             playlist.current_song = playlist.playque[0]
             logger.debug(f"{getTime()}: _play_song iterating current_song to {playlist.playque[0].title}.")
@@ -446,7 +447,7 @@ class Player(commands.Cog):
                             await ctx.send(embed=Embed(title="Download Error", description=f"{e}"))
                             playlist.remove(autoplay_song) # removes the song without adding it to playhistory, since it wasn't played
                             helper.cleanupSong(autoplay_song.slug_title)
-                await ctx.send(embed=Embed(title=f"Up Next", description=f"{playlist.playque[0]}\n"))
+                await ctx.send(embed=Embed(title=f"Up Next", description=f"{playlist.playque[0].title}\n"))
             return
             
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -105,10 +105,12 @@ class PlayList(commands.Cog):
         if len(self.playhistory) > 1:
             pretty_string = ""
             pretty_string += f"Playing: {self.current_song.title}\n\n"
-            count = 1 # skip the first song in playque
-            for song in self.playhistory:
-                pretty_string += f"{count}: {song.title}\n"
-                count += 1
+            playhistory = self.playhistory.copy()
+            playhistory.pop() # copy current playhistory, leaving popping off the most recent edition (the current song)
+            playhistory_with_index = enumerate(self.playhistory, start=1)
+
+            for index, song in playhistory_with_index: # skip first song in playhistory as this is the current song
+                pretty_string += f"{index}: {song.title}\n"
             await ctx.send(embed = Embed(title=f"Recently Played", description=f"{pretty_string}"))
         else:
             await ctx.send(embed = Embed(title=f"No songs have been played yet."))
@@ -277,7 +279,7 @@ class Player(commands.Cog):
             playlist.current_song = playlist.playque[0]
             playlist.playque.pop()
             song_titles_to_save = [song.slug_title for song in playlist.playque] + [playlist.current_song.slug_title]
-            playlist.playhistory.appendleft(playlist.current_song)
+            playlist.playhistory.append(playlist.current_song)
             try:
                 helper.deleteSongsBesidesThese(song_titles_to_save)
                 logger.info(f"{time.asctime(time.localtime())}: ParkBot deleted all songs besides those in this list, {song_titles_to_save}")

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -259,16 +259,16 @@ class Player(commands.Cog):
         # print(f"***starting _play_song method")
         playlist = self.playlist
         if not playlist.isEmpty():
-            logger.debug(f"{getTime()}: Playlist is not empty! Contents: {[song.title for song in playlist.playque]}")
+            # logger.debug(f"{getTime()}: Playlist is not empty! Contents: {[song.title for song in playlist.playque]}")
             if self.voice.is_playing():
-                # print(f"A song is already playing! Will return early from _play_song call.")
                 return
             playlist.current_song = playlist.playque[0]
-            playlist.pop()
+            playlist.playque.pop()
             songs_to_delete = [song.slug_title for song in playlist.playhistory]
+            playlist.playhistory.appendleft(playlist.current_song)
             try:
                 helper.deleteTheseFiles(songs_to_delete)
-                logger.info(f"{time.asctime(time.localtime())}: ParkBot deleted already-played songs.")
+                logger.info(f"{time.asctime(time.localtime())}: ParkBot deleted already-played songs, {songs_to_delete}")
             except:
                 pass
             # print(f"Loading current song from this path: {playlist.current_song.path}")

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -15,7 +15,6 @@ from discord.ext import commands
 from mutagen import mp3
 import yt_dlp
 from youtube_dl import YoutubeDL
-from parkproxies.proxy_service import ProxyService
 
 # new music specific log
 music_handler = logging.FileHandler(f"{WORKING_DIRECTORY}music.log", encoding="utf-8", mode="w")

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -76,7 +76,7 @@ class Song:
 class PlayList(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.current_song:Song = None
+        self.current_song:Song = None 
         self.prev_song:Song = None
         self.playque:deque[Song] = deque()
         self.playhistory = deque(maxlen=5)
@@ -292,6 +292,7 @@ class Player(commands.Cog):
                 self.voice.play(source = audio, after = self.play_next)
 
     #TODO make bot join different voice channel if caller is in different voice channel than bot
+    #TODO current song is being handled incorrectly, example: when skipping last song in queue, "showQ" still shows the now skipped song as the current song.
     async def _play(self, ctx, *args) -> None:
         playlist = self.playlist
         new_song = Song()
@@ -333,7 +334,7 @@ class Player(commands.Cog):
     
     async def _skip(self, ctx):
         playlist = self.playlist
-        if playlist.current_song:
+        if playlist.current_song is not None:
             await ctx.send(embed=Embed(title=f"Skipping {playlist.current_song.title}."))
             self.voice.stop()
             self.playing = False
@@ -345,6 +346,7 @@ class Player(commands.Cog):
             await ctx.send(embed=Embed(title=f"Queue is already empty."))
 
     async def leaveWhenDone(self, ctx):
+        playlist = self.playlist
         print(f"sleeping for 600 seconds before checking if voice is playing")    
         await asyncio.sleep(600.0)
         # this didn't work last time, INVESTIGATE!
@@ -359,7 +361,7 @@ class Player(commands.Cog):
                         await self.voice.disconnect()
                         await ctx.send(embed=Embed(title=f'Left voice chat due to inactivity.'))
                         self.voice = None
-                        self.current_song = None
+                        playlist.current_song = None
                         return
                     except Exception as e:
                         error_message = await ctx.send(f"Bot was cleared to leave the voice channel, however It was unable to execute this action. Exception: {e}")
@@ -370,7 +372,7 @@ class Player(commands.Cog):
                     await self.leaveWhenDone(ctx)
             elif not self.voice.is_connected():
                 print(f"self.voice is already disconnected. setting self.voice to none.")
-                self.current_song = None
+                playlist.current_song = None
                 self.voice = None
                 return
         else:

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -15,6 +15,7 @@ from discord.ext import commands
 from mutagen import mp3
 import yt_dlp
 from youtube_dl import YoutubeDL
+from parkproxies.proxy_service import ProxyService
 
 # new music specific log
 music_handler = logging.FileHandler(f"{WORKING_DIRECTORY}music.log", encoding="utf-8", mode="w")
@@ -222,8 +223,9 @@ class Player(commands.Cog):
         playlist = self.playlist
         self.playing = False
         playlist.prev_song = playlist.current_song
-        songs_to_delete = [song.slug_title for song in playlist.playhistory]
+        songs_to_delete = [song.slug_title for song in playlist.playhistory if song not in playlist.playque]
         helper.deleteTheseFiles(songs_to_delete)
+        logger.info(f"{time.asctime(time.localtime())}: ParkBot deleted already-played songs, {songs_to_delete}")
         if not playlist.isEmpty():
             if not self.from_skip: # if coming from a skip, don't iterate current song to the next song. (why? current song should be None if coming from a skip.)
                 playlist.current_song = playlist.playque[0]
@@ -264,7 +266,7 @@ class Player(commands.Cog):
                 return
             playlist.current_song = playlist.playque[0]
             playlist.playque.pop()
-            songs_to_delete = [song.slug_title for song in playlist.playhistory]
+            songs_to_delete = [song.slug_title for song in playlist.playhistory if song not in playlist.playque]
             playlist.playhistory.appendleft(playlist.current_song)
             try:
                 helper.deleteTheseFiles(songs_to_delete)

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -269,7 +269,6 @@ class Player(commands.Cog):
             try:
                 helper.deleteTheseFiles(songs_to_delete)
                 logger.info(f"{time.asctime(time.localtime())}: ParkBot deleted already-played songs.")
->>>>>>> Stashed changes
             except:
                 pass
             # print(f"Loading current song from this path: {playlist.current_song.path}")

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -12,7 +12,6 @@ from googleapiclient.errors import HttpError # can be thrown when max amount of 
 import discord
 from discord import Embed
 from discord.ext import commands
-from discord import VoiceClient
 from mutagen import mp3
 import yt_dlp
 from youtube_dl import YoutubeDL
@@ -24,7 +23,6 @@ logger.addHandler(music_handler)
 
 def getTime() -> str:
     return time.asctime(time.localtime())
->>>>>>> Stashed changes
 
 # current goal:
     # refactor cogs (starting with music) to allow bot to serve all cogs to more than one server at one time. (user story: I can use ParkBot music feature simaltaneously from two different discord servers.)
@@ -239,7 +237,7 @@ class Player(commands.Cog):
                 except yt_dlp.utils.DownloadError:
                     logger.error(f"{getTime()}: The video you wanted to download was too large. Deleting this song from the queue.")
                     playlist.remove(next_song)
-                    helper.deleteAudioFile(next_song.slug_title)
+                    helper.cleanupSong(next_song.slug_title)
             # otherwise, pre download a song ahead in the queue after a song is playing
             audio = discord.FFmpegPCMAudio(playlist.current_song.path, executable=FFMPEG_PATH)
             if self.playing is False:
@@ -252,7 +250,7 @@ class Player(commands.Cog):
                         self.client.downloadSong(preload_song)
                     except yt_dlp.utils.DownloadError:
                         logger.error(f"{time.asctime(time.localtime())}: Error preloading the next undownloaded song in play_next method")
-                        helper.deleteAudioFile(preload_song.slug_title)
+                        helper.cleanupSong(preload_song.slug_title)
         elif err:
             logger.error(f"{getTime()}: Error in play_next method: {err}" )
             return
@@ -306,7 +304,7 @@ class Player(commands.Cog):
                     logger.error(f"{time.asctime(time.localtime())}: ParkBot {ctx.guild} instance had a download Error - {e}", exc_info=True, stack_info=True)
                     await ctx.send(embed=Embed(title="Download Error", description=f"{e}"))
                     playlist.remove(new_song) # removes the song without adding it to playhistory, since it wasn't played
-                    helper.deleteAudioFile(new_song.slug_title)
+                    helper.cleanupSong(new_song.slug_title)
             # check if there's already a voice connection
 
             if self.voice is None:

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -369,6 +369,7 @@ class MusicController(Controller):
     and Player for each guild the ParkBot is a part of. The `play` and `skip` commands access the appropriate Player instance,\n
     then execute the lower level `_play` or `_skip` commands on the instance. In other words, the MusicController directs users' commands
     to their guild's instance of the ParkBot."""
+
     # the songs_to_save doesn't 
     def __init__(self, bot):
         logger.info(f"{time.asctime(time.localtime())}: MusicController constructed.")

--- a/config/example_config.py
+++ b/config/example_config.py
@@ -1,19 +1,24 @@
 # save a filled out version of this file as config.py, in this directory.
 
-# this config file uses windows style back slashes in directory naming - you may need to change all '\\' to '/' to run on a linux machine
+# this config file uses windows-style back slashes in directory naming - you may need to change all '\\' to '/' to run on a linux machine
+
 
 # pound sign legend: 
 
 # == this variable is necessary for the discord Bot to run
-## == this variable is necessary for the Music feature
+## == this variable is necessary for the Music feature 
 ### == this variable is necessary for the Canvas feature
-
+#### == this variable is optional
 
 TOKEN = '' # this is your Discord API token, the soul of your Discord Bot
 
 WORKING_DIRECTORY = "" # this should be the path to your local instance of the ParkBot repository, ie "C:/Users/Parker/Documents/GitHub-Repos/ParkBot/"
 
 GOOGLE_API_KEY = '' ## a google API key is necessary to host the Music feature, since searching for songs on youtube (within google's TOS) requires a key.
+
+SPOTIFY_CLIENT_ID = "" #### Client ID provided by spotify, used to access the Spotify API. use this for access to the music 'autoplay' feature.
+
+SPOTIFY_CLIENT_SECRET = "" #### The api-key corresponding to your spotify client ID. Make sure to provide this value in conjunction with your client ID to allow the music 'autoplay' feature to work.
 
 FFMPEG_PATH = "C:/Program Files/FFmpeg/bin/ffmpeg.exe" ## (the current value of FFMPEG_PATH is an example) this is the path to your FFMPEG executable. this exe will be used to process audio (music) before it can be played.
 

--- a/helper.py
+++ b/helper.py
@@ -52,7 +52,7 @@ def slugify(string):
             new_string += letter
     return new_string
 
-def cleanAudioFile(song_name):
+def deleteAudioFile(song_name):
     os.chdir(DATA_DIRECTORY)
     # in data directory 
 
@@ -105,6 +105,22 @@ def deleteSongsBesidesThese(slugified_song_titles:list) -> None:
             except Exception as e:
                 print(e)
 
+    os.chdir(WORKING_DIRECTORY)
+
+def deleteTheseFiles(file_paths:list) -> None:
+    "Deletes all .webm, .ytdl, and .mp3 files which are included in the file_paths parameter."
+    os.chdir(DATA_DIRECTORY)
+    files = os.listdir(os.getcwd())
+    for file in files:
+        # delete any songs that are webm or ytdl extensions
+        if (str(file) in file_paths):
+            way = os.getcwd()
+            way += f"\\{file}"
+            try:
+                os.remove(way)
+            except Exception as e:
+                print(e)
+    
     os.chdir(WORKING_DIRECTORY)
 
 def write_iterable(file_path:str, iterable:list | dict) -> None:

--- a/helper.py
+++ b/helper.py
@@ -52,14 +52,13 @@ def slugify(string):
             new_string += letter
     return new_string
 
-def deleteAudioFile(song_name):
+def cleanupSong(song_path):
+    """Remove leftover files from a failed yt_dlp download."""
     os.chdir(DATA_DIRECTORY)
-    # in data directory 
-
     files = os.listdir(os.getcwd())
     for file in files:
         # if the file minus the .mp3 extension equals input song name
-        if str(file[:-4]) == song_name:
+        if (str(file[:-4]) == song_path) or (str(file[:-5]) == song_path):
             try:
                 os.remove(file)
             except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,10 +46,11 @@ requests==2.28.1
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
+soupsieve==2.4.1
 typing_extensions==4.3.0
 uritemplate==4.1.1
 urllib3==1.26.12
 websockets==11.0.1
 yarl==1.8.1
 youtube-dl==2021.12.17
-yt-dlp==2023.3.4
+yt-dlp==2023.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,12 +41,14 @@ python-dateutil==2.8.2
 pyttsx3==2.90
 pytz==2022.7.1
 pywin32==306
+redis==5.0.0
 replicate==0.4.0
 requests==2.28.1
 requests-oauthlib==1.3.1
 rsa==4.9
 six==1.16.0
 soupsieve==2.4.1
+spotipy==2.23.0
 typing_extensions==4.3.0
 uritemplate==4.1.1
 urllib3==1.26.12


### PR DESCRIPTION
- added spotify client library to utilize their song recommendations for autoplay
- autoplay can be turned on or off using `autoplay <arg>`
- modified bot voice client logic - it now joins immediately after any `play` is called
- skip function seems to still have an issue - seems like when skip is called, the original play functions call to `play_next()` still executes as the skips call to `_play_song()` - need to find some way to negate the call to play_next or avoid calling `_play_song()` from skip.
- updated yt-dlp version, older version was getting a lot of 403 errors while downloading